### PR TITLE
Setting agent to true for windows

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -257,6 +257,7 @@ resource "null_resource" "bootstrap" {
   connection {
     host = "${var.bootstrap_ip}"
     user = "${var.os_user}"
+    agent= true
   }
 
   provisioner "file" {


### PR DESCRIPTION
SSH using pageant doesn't work on Windows without explicitly setting agent to true